### PR TITLE
Rebalance field events across map

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,20 @@
             <!-- フィールド -->
             <div id="field">
                 <!-- 街 -->
-                <div class="town" style="position: absolute; left: 80px; top: 80px;">
+                <div class="town" style="position: absolute; left: 60px; top: 80px;">
                     <div class="building">🏠</div>
+                </div>
+
+                <!-- 店 -->
+                <div class="town" style="position: absolute; left: 300px; top: 80px;">
                     <div class="building">🏪</div>
+                </div>
+
+                <!-- 教会 -->
+                <div class="town" style="position: absolute; left: 60px; top: 300px;">
                     <div class="building">⛪</div>
                 </div>
-                
+
                 <!-- 山 -->
                 <div class="mountain" style="position: absolute; left: 300px; top: 60px;">
                     <div class="mountain-peak">⛰️</div>
@@ -52,7 +60,7 @@
                 </div>
                 
                 <!-- その他の地形 -->
-                <div class="forest" style="position: absolute; left: 200px; top: 300px;">
+                <div class="forest" style="position: absolute; left: 300px; top: 300px;">
                     <div style="font-size: 30px;">🌲🌳🌲</div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -53,9 +53,9 @@ const enemies = {
 // フィールドイベント（新しい地形を含む）
 const fieldEvents = [
     // 街のイベント
-    { x: 80, y: 80, type: 'town', message: 'ヒカリの街へようこそ！\nここは平和な街です。' },
-    { x: 100, y: 80, type: 'shop', message: 'よろず屋です！\n回復アイテムを手に入れた！' },
-    { x: 120, y: 80, type: 'church', message: 'ここは教会です。\nHPとMPが全回復しました！' },
+    { x: 60, y: 80, type: 'town', message: 'ヒカリの街へようこそ！\nここは平和な街です。' },
+    { x: 300, y: 80, type: 'shop', message: 'よろず屋です！\n回復アイテムを手に入れた！' },
+    { x: 60, y: 300, type: 'church', message: 'ここは教会です。\nHPとMPが全回復しました！' },
     
     // 山のイベント
     { x: 300, y: 60, type: 'mountain', message: '高い山です。\n見晴らしがとてもいいですね！' },
@@ -68,16 +68,16 @@ const fieldEvents = [
     { x: 350, y: 280, type: 'dungeon', enemy: 'demon' },
     
     // 森のイベント
-    { x: 220, y: 300, type: 'forest', message: '深い森です。\n小鳥の鳴き声が聞こえます。' },
+    { x: 300, y: 300, type: 'forest', message: '深い森です。\n小鳥の鳴き声が聞こえます。' },
     
     // 戦闘イベント
-    { x: 120, y: 160, type: 'battle', enemy: 'slime' },
+    { x: 160, y: 160, type: 'battle', enemy: 'slime' },
     { x: 280, y: 140, type: 'battle', enemy: 'goblin' },
-    { x: 80, y: 320, type: 'battle', enemy: 'slime' },
+    { x: 300, y: 320, type: 'battle', enemy: 'slime' },
     
     // 宝箱イベント
-    { x: 50, y: 50, type: 'treasure', message: 'きらきら光る宝箱を見つけた！\nやる気が10回復した！' },
-    { x: 380, y: 320, type: 'treasure', message: '古い宝箱を発見！\nHPが20回復した！' }
+    { x: 350, y: 50, type: 'treasure', message: 'きらきら光る宝箱を見つけた！\nやる気が10回復した！' },
+    { x: 50, y: 350, type: 'treasure', message: '古い宝箱を発見！\nHPが20回復した！' }
 ];
 
 // BGM管理


### PR DESCRIPTION
## Summary
- Separate town, shop, and church into individual buildings and spread them across the field for better balance.
- Adjust field event coordinates to match new layout and distribute battles and treasures.

## Testing
- `node --check script.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689124b356e08330bc3e1980e871fd5f