### PR TITLE
Refine field layout and enhance visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,61 +26,64 @@
             <!-- フィールド -->
             <div id="field">
                 <!-- 街 -->
-                <div class="town" style="position: absolute; left: 60px; top: 80px;">
+                <div class="town" style="position: absolute; left: 80px; top: 80px;">
                     <div class="building">🏠</div>
                 </div>
 
                 <!-- 店 -->
-                <div class="town" style="position: absolute; left: 300px; top: 80px;">
+                <div class="town" style="position: absolute; left: 280px; top: 80px;">
                     <div class="building">🏪</div>
                 </div>
 
                 <!-- 教会 -->
-                <div class="town" style="position: absolute; left: 60px; top: 300px;">
+                <div class="town" style="position: absolute; left: 80px; top: 320px;">
                     <div class="building">⛪</div>
                 </div>
 
                 <!-- 山 -->
-                <div class="mountain" style="position: absolute; left: 300px; top: 60px;">
+                <div class="mountain" style="position: absolute; left: 320px; top: 40px;">
                     <div class="mountain-peak">⛰️</div>
                     <div class="mountain-peak">🏔️</div>
                 </div>
-                
+
                 <!-- 川 -->
                 <div class="river" style="position: absolute; left: 0px; top: 200px; width: 400px; height: 40px; background: linear-gradient(90deg, #74b9ff, #0984e3); border-radius: 20px;"></div>
-                
+
                 <!-- 橋 -->
-                <div class="bridge" style="position: absolute; left: 160px; top: 190px; width: 80px; height: 60px; background: #8B4513; border-radius: 10px; z-index: 10;">
-                    <div style="text-align: center; line-height: 60px; font-size: 20px;">🌉</div>
+                <div class="bridge" style="position: absolute; left: 160px; top: 200px; width: 80px; height: 40px; background: #8B4513; border-radius: 10px; z-index: 10;">
+                    <div style="text-align: center; line-height: 40px; font-size: 20px;">🌉</div>
                 </div>
-                
-                <!-- 洞窟 -->
-                <div class="cave" style="position: absolute; left: 350px; top: 280px;">
+
+                <!-- 洞窟（ダンジョン） -->
+                <div class="cave" style="position: absolute; left: 360px; top: 280px;">
                     <div style="font-size: 40px;">🕳️</div>
                 </div>
-                
+
                 <!-- その他の地形 -->
-                <div class="forest" style="position: absolute; left: 300px; top: 300px;">
+                <div class="forest" style="position: absolute; left: 320px; top: 320px;">
                     <div style="font-size: 30px;">🌲🌳🌲</div>
                 </div>
             </div>
-            
+
             <!-- SVG勇者プレイヤー -->
-            <div id="player" class="character" style="top: 250px; left: 200px;">
+            <div id="player" class="character" style="top: 240px; left: 200px;">
                 <svg width="40" height="40" viewBox="0 0 40 40" id="playerSvg">
                     <!-- 体 -->
-                    <ellipse cx="20" cy="30" rx="8" ry="10" fill="#4a90e2" stroke="#2c3e50" stroke-width="1"/>
+                    <ellipse cx="20" cy="30" rx="8" ry="10" fill="#5dade2" stroke="#2c3e50" stroke-width="1"/>
                     <!-- 頭 -->
                     <circle cx="20" cy="15" r="10" fill="#fdbcb4" stroke="#2c3e50" stroke-width="1"/>
                     <!-- 髪 -->
                     <path d="M10 12 Q20 5 30 12 Q25 8 20 8 Q15 8 10 12" fill="#8b4513"/>
                     <!-- 目 -->
-                    <circle cx="16" cy="13" r="2" fill="white"/>
-                    <circle cx="24" cy="13" r="2" fill="white"/>
-                    <circle cx="16" cy="13" r="1" fill="black"/>
-                    <circle cx="24" cy="13" r="1" fill="black"/>
+                    <circle cx="16" cy="13" r="3" fill="white"/>
+                    <circle cx="24" cy="13" r="3" fill="white"/>
+                    <circle cx="16" cy="13" r="1.5" fill="black"/>
+                    <circle cx="24" cy="13" r="1.5" fill="black"/>
+                    <!-- ほっぺ -->
+                    <circle cx="16" cy="18" r="1.5" fill="#ff8c94" opacity="0.8"/>
+                    <circle cx="24" cy="18" r="1.5" fill="#ff8c94" opacity="0.8"/>
                     <!-- 口 -->
-                    <path d="M18 18 Q20 20 22 18" stroke="#2c3e50" stroke-width="1" fill="none"/>
+                    <path d="M18 19 Q20 21 22 19" stroke="#2c3e50" stroke-width="1" fill="none"/>
                     <!-- 腕 -->
                     <ellipse cx="12" cy="25" rx="3" ry="8" fill="#fdbcb4" stroke="#2c3e50" stroke-width="1"/>
                     <ellipse cx="28" cy="25" rx="3" ry="8" fill="#fdbcb4" stroke="#2c3e50" stroke-width="1"/>

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ let gameState = {
         name: 'カケル',
         gender: 'boy',
         x: 200,
-        y: 250,
+        y: 240,
         hp: 100,
         maxHp: 100,
         mp: 50,
@@ -53,31 +53,31 @@ const enemies = {
 // フィールドイベント（新しい地形を含む）
 const fieldEvents = [
     // 街のイベント
-    { x: 60, y: 80, type: 'town', message: 'ヒカリの街へようこそ！\nここは平和な街です。' },
-    { x: 300, y: 80, type: 'shop', message: 'よろず屋です！\n回復アイテムを手に入れた！' },
-    { x: 60, y: 300, type: 'church', message: 'ここは教会です。\nHPとMPが全回復しました！' },
-    
+    { x: 80, y: 80, type: 'town', message: 'ヒカリの街へようこそ！\nここは平和な街です。' },
+    { x: 280, y: 80, type: 'shop', message: 'よろず屋です！\n回復アイテムを手に入れた！' },
+    { x: 80, y: 320, type: 'church', message: 'ここは教会です。\nHPとMPが全回復しました！' },
+
     // 山のイベント
-    { x: 300, y: 60, type: 'mountain', message: '高い山です。\n見晴らしがとてもいいですね！' },
-    { x: 320, y: 60, type: 'cave', message: '山の洞窟を発見！\n中は暗くて怖そうです...' },
-    
+    { x: 320, y: 40, type: 'mountain', message: '高い山です。\n見晴らしがとてもいいですね！' },
+    { x: 360, y: 80, type: 'cave', message: '山の洞窟を発見！\n中は暗くて怖そうです...' },
+
     // 橋のイベント
-    { x: 200, y: 210, type: 'bridge', message: 'きれいな石の橋です。\n川を渡ることができます。' },
-    
+    { x: 160, y: 200, type: 'bridge', message: 'きれいな石の橋です。\n川を渡ることができます。' },
+
     // 洞窟のイベント
-    { x: 350, y: 280, type: 'dungeon', enemy: 'demon' },
-    
+    { x: 360, y: 280, type: 'dungeon', enemy: 'demon' },
+
     // 森のイベント
-    { x: 300, y: 300, type: 'forest', message: '深い森です。\n小鳥の鳴き声が聞こえます。' },
-    
+    { x: 320, y: 320, type: 'forest', message: '深い森です。\n小鳥の鳴き声が聞こえます。' },
+
     // 戦闘イベント
     { x: 160, y: 160, type: 'battle', enemy: 'slime' },
-    { x: 280, y: 140, type: 'battle', enemy: 'goblin' },
-    { x: 300, y: 320, type: 'battle', enemy: 'slime' },
-    
+    { x: 240, y: 160, type: 'battle', enemy: 'goblin' },
+    { x: 240, y: 320, type: 'battle', enemy: 'slime' },
+
     // 宝箱イベント
-    { x: 350, y: 50, type: 'treasure', message: 'きらきら光る宝箱を見つけた！\nやる気が10回復した！' },
-    { x: 50, y: 350, type: 'treasure', message: '古い宝箱を発見！\nHPが20回復した！' }
+    { x: 360, y: 40, type: 'treasure', message: 'きらきら光る宝箱を見つけた！\nやる気が10回復した！' },
+    { x: 40, y: 360, type: 'treasure', message: '古い宝箱を発見！\nHPが20回復した！' }
 ];
 
 // BGM管理

--- a/style.css
+++ b/style.css
@@ -235,6 +235,7 @@ body {
   padding: 15px;
   height: 35vh;
   overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 /* ステータスパネル */
@@ -247,6 +248,8 @@ body {
   background: linear-gradient(135deg, #74b9ff, #0984e3);
   border-radius: 8px;
   color: white;
+  font-size: 1.1rem;
+  border: 3px solid #2980b9;
 }
 
 .status-item {
@@ -262,10 +265,11 @@ body {
   border-radius: 10px;
   margin-bottom: 15px;
   border: 2px solid #3498db;
+  box-shadow: 0 0 10px rgba(52, 152, 219, 0.7);
 }
 
 #messageText {
-  font-size: 1.1rem;
+  font-size: 1.2rem;
   line-height: 1.5;
   margin-bottom: 15px;
 }
@@ -446,7 +450,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 25px;
+  font-size: 30px;
   cursor: pointer;
   z-index: 5;
   transition: all 0.3s ease;


### PR DESCRIPTION
## Summary
- Align field elements on a 40px grid and add a cuter hero sprite with rosy cheeks.
- Improve UI visibility with larger fonts, stronger borders, and shadowed panels.
- Enlarge field event icons for clearer exploration cues.

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/37-RPG/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6892800925608330ba6182f265073663