### PR TITLE
Rearrange game UI for easier play

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,12 @@
 
     <!-- ゲーム画面 -->
     <div id="gameScreen" class="screen hidden">
+        <!-- メッセージウィンドウ -->
+        <div id="messageWindow" class="hidden">
+            <p id="messageText"></p>
+            <button id="messageNext" onclick="nextMessage()">つぎへ ▶</button>
+        </div>
+
         <!-- ゲームエリア -->
         <div id="gameArea">
             <!-- フィールド -->
@@ -91,43 +97,34 @@
             </div>
         </div>
 
-        <!-- UI エリア -->
-        <div id="uiArea">
-            <!-- ステータス -->
-            <div id="statusPanel">
-                <div class="status-item">
-                    <span>なまえ：</span><span id="playerName">カケル</span>
-                </div>
-                <div class="status-item">
-                    <span>HP：</span><span id="playerHP">100</span><span>/</span><span id="playerMaxHP">100</span>
-                </div>
-                <div class="status-item">
-                    <span>やる気：</span><span id="playerMP">50</span><span>/</span><span id="playerMaxMP">50</span>
-                </div>
-                <div class="status-item">
-                    <span>レベル：</span><span id="playerLevel">1</span>
-                </div>
+        <!-- 移動ボタン（スマホ用） -->
+        <div id="mobileControls">
+            <div class="control-row">
+                <button class="move-btn" onclick="movePlayer('up')">↑</button>
             </div>
-
-            <!-- メッセージウィンドウ -->
-            <div id="messageWindow" class="hidden">
-                <p id="messageText"></p>
-                <button id="messageNext" onclick="nextMessage()">つぎへ ▶</button>
+            <div class="control-row">
+                <button class="move-btn" onclick="movePlayer('left')">←</button>
+                <button class="move-btn" onclick="checkEvent()">調べる</button>
+                <button class="move-btn" onclick="movePlayer('right')">→</button>
             </div>
+            <div class="control-row">
+                <button class="move-btn" onclick="movePlayer('down')">↓</button>
+            </div>
+        </div>
 
-            <!-- 移動ボタン（スマホ用） -->
-            <div id="mobileControls">
-                <div class="control-row">
-                    <button class="move-btn" onclick="movePlayer('up')">↑</button>
-                </div>
-                <div class="control-row">
-                    <button class="move-btn" onclick="movePlayer('left')">←</button>
-                    <button class="move-btn" onclick="checkEvent()">調べる</button>
-                    <button class="move-btn" onclick="movePlayer('right')">→</button>
-                </div>
-                <div class="control-row">
-                    <button class="move-btn" onclick="movePlayer('down')">↓</button>
-                </div>
+        <!-- ステータス -->
+        <div id="statusPanel">
+            <div class="status-item">
+                <span>なまえ：</span><span id="playerName">カケル</span>
+            </div>
+            <div class="status-item">
+                <span>HP：</span><span id="playerHP">100</span><span>/</span><span id="playerMaxHP">100</span>
+            </div>
+            <div class="status-item">
+                <span>やる気：</span><span id="playerMP">50</span><span>/</span><span id="playerMaxMP">50</span>
+            </div>
+            <div class="status-item">
+                <span>レベル：</span><span id="playerLevel">1</span>
             </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -228,21 +228,12 @@ body {
   transform: scaleX(1);
 }
 
-/* UIエリア */
-#uiArea {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 10px;
-  padding: 15px;
-  height: 35vh;
-  overflow-y: auto;
-}
-
 /* ステータスパネル */
 #statusPanel {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
-  margin-bottom: 15px;
+  margin: 10px auto;
   padding: 10px;
   background: linear-gradient(135deg, #74b9ff, #0984e3);
   border-radius: 8px;
@@ -256,12 +247,17 @@ body {
 
 /* メッセージウィンドウ */
 #messageWindow {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 90%;
   background: rgba(0, 0, 0, 0.8);
   color: white;
   padding: 20px;
   border-radius: 10px;
-  margin-bottom: 15px;
   border: 2px solid #3498db;
+  z-index: 20;
 }
 
 #messageText {
@@ -356,7 +352,8 @@ body {
 #mobileControls {
   display: grid;
   gap: 5px;
-  margin-top: 10px;
+  margin: 10px auto;
+  justify-content: center;
 }
 
 .control-row {
@@ -491,10 +488,6 @@ body {
       height: 50vh;
   }
   
-  #uiArea {
-      height: 45vh;
-  }
-  
   #statusPanel {
       grid-template-columns: 1fr;
       font-size: 0.9rem;
@@ -541,11 +534,6 @@ body {
   
   #gameArea {
       height: 45vh;
-  }
-  
-  #uiArea {
-      height: 50vh;
-      padding: 10px;
   }
   
   .enemy-image {


### PR DESCRIPTION
## Summary
- Move message window to top of the game screen
- Place mobile controls directly under the map and separate the status panel
- Clean up unused UI wrapper styles

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68932544b8b483309b707718552bbed3