### PR TITLE
Add distinct terrain tiles

### DIFF
--- a/images/tiles/forest.svg
+++ b/images/tiles/forest.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+  <rect width="40" height="40" fill="#145A32"/>
+  <path d="M20 5 L30 35 L10 35 Z" fill="#196F3D"/>
+  <rect x="18" y="25" width="4" height="10" fill="#6E2C00"/>
+</svg>

--- a/images/tiles/grass.svg
+++ b/images/tiles/grass.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+  <rect width="40" height="40" fill="#6ab04c"/>
+  <path d="M0 20h40M20 0v40" stroke="#27ae60" stroke-width="2"/>
+</svg>

--- a/images/tiles/road.svg
+++ b/images/tiles/road.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+  <rect width="40" height="40" fill="#d5d8dc"/>
+  <path d="M0 20h40M20 0v40" stroke="#a6acaf" stroke-width="2"/>
+</svg>

--- a/images/tiles/water.svg
+++ b/images/tiles/water.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+  <rect width="40" height="40" fill="#74b9ff"/>
+  <path d="M0 10 Q10 0 20 10 T40 10" stroke="#0984e3" stroke-width="2" fill="none"/>
+  <path d="M0 30 Q10 20 20 30 T40 30" stroke="#0984e3" stroke-width="2" fill="none"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -30,19 +30,19 @@
         <!-- ゲームエリア -->
         <div id="gameArea">
             <!-- フィールド -->
-            <div id="field">
+            <div id="field" class="tile-grass">
                 <!-- 街 -->
-                <div class="town" style="position: absolute; left: 60px; top: 80px;">
+                <div class="town tile-road" style="position: absolute; left: 60px; top: 80px; width: 80px; height: 80px;">
                     <div class="building">🏠</div>
                 </div>
 
                 <!-- 店 -->
-                <div class="town" style="position: absolute; left: 300px; top: 80px;">
+                <div class="town tile-road" style="position: absolute; left: 300px; top: 80px; width: 80px; height: 80px;">
                     <div class="building">🏪</div>
                 </div>
 
                 <!-- 教会 -->
-                <div class="town" style="position: absolute; left: 60px; top: 300px;">
+                <div class="town tile-road" style="position: absolute; left: 60px; top: 300px; width: 80px; height: 80px;">
                     <div class="building">⛪</div>
                 </div>
 
@@ -53,10 +53,10 @@
                 </div>
                 
                 <!-- 川 -->
-                <div class="river" style="position: absolute; left: 0px; top: 200px; width: 400px; height: 40px; background: linear-gradient(90deg, #74b9ff, #0984e3); border-radius: 20px;"></div>
+                <div class="river tile-water" style="position: absolute; left: 0px; top: 200px; width: 400px; height: 40px; border-radius: 20px;"></div>
                 
                 <!-- 橋 -->
-                <div class="bridge" style="position: absolute; left: 160px; top: 190px; width: 80px; height: 60px; background: #8B4513; border-radius: 10px; z-index: 10;">
+                <div class="bridge tile-road" style="position: absolute; left: 160px; top: 190px; width: 80px; height: 60px; border-radius: 10px; z-index: 10;">
                     <div style="text-align: center; line-height: 60px; font-size: 20px;">🌉</div>
                 </div>
                 
@@ -66,9 +66,7 @@
                 </div>
                 
                 <!-- その他の地形 -->
-                <div class="forest" style="position: absolute; left: 300px; top: 300px;">
-                    <div style="font-size: 30px;">🌲🌳🌲</div>
-                </div>
+                <div class="forest tile-forest" style="position: absolute; left: 300px; top: 300px;"></div>
             </div>
             
             <!-- SVG勇者プレイヤー -->

--- a/style.css
+++ b/style.css
@@ -121,21 +121,39 @@ body {
 #field {
   width: 100%;
   height: 100%;
-  background-image: 
-      linear-gradient(45deg, #2ecc71 25%, transparent 25%),
-      linear-gradient(-45deg, #2ecc71 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, #2ecc71 75%),
-      linear-gradient(-45deg, transparent 75%, #2ecc71 75%);
-  background-size: 40px 40px;
-  background-position: 0 0, 0 20px, 20px -20px, -20px 0px;
   position: relative;
+}
+
+/* タイル */
+.tile-grass,
+.tile-forest,
+.tile-water,
+.tile-road {
+  background-size: 40px 40px;
+  background-repeat: repeat;
+}
+
+.tile-grass {
+  background-image: url('images/tiles/grass.svg');
+}
+
+.tile-forest {
+  background-image: url('images/tiles/forest.svg');
+}
+
+.tile-water {
+  background-image: url('images/tiles/water.svg');
+}
+
+.tile-road {
+  background-image: url('images/tiles/road.svg');
 }
 
 /* 地形要素 */
 .town {
   display: flex;
-  gap: 10px;
-  background: rgba(139, 69, 19, 0.3);
+  align-items: center;
+  justify-content: center;
   padding: 10px;
   border-radius: 10px;
   border: 2px solid #8B4513;
@@ -171,6 +189,8 @@ body {
 }
 
 .forest {
+  width: 80px;
+  height: 80px;
   animation: forestWave 2s ease-in-out infinite;
 }
 


### PR DESCRIPTION
## Summary
- Introduce reusable tile classes for grass, forest, water and road terrains
- Apply new tile styles to towns, river, bridge and forest on the map
- Add simple SVG assets for each terrain type

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689340ae01bc833096608a3eb8cc34b1