### PR TITLE
Improve mobile battle UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>ヒカリノオウコク - 魔石と子どもたちの冒険</title>
     <link rel="stylesheet" href="style.css">
 </head>
@@ -24,7 +24,7 @@
         <!-- メッセージボックス -->
         <div id="messageBox" class="hidden">
             <p id="messageText"></p>
-            <button id="messageNext" onclick="nextMessage()">つぎへ ▶</button>
+            <button id="messageNext" class="next-button" onclick="nextMessage()">つぎへ ▶</button>
         </div>
 
         <!-- ゲームエリア -->
@@ -128,7 +128,7 @@
 
         <!-- 戦闘画面 -->
         <div id="battleScreen" class="hidden">
-            <div class="battle-area">
+            <div class="battle-area battle-modal">
                 <div class="enemy-area">
                     <img id="enemyImage" class="enemy-image" src="" alt="敵">
                     <div id="enemyInfo">
@@ -137,10 +137,10 @@
                     </div>
                 </div>
                 <div class="battle-menu">
-                    <button class="battle-btn" onclick="attack()">こうげき</button>
-                    <button class="battle-btn" onclick="useSkill()">とくぎ</button>
-                    <button class="battle-btn" onclick="useItem()">どうぐ</button>
-                    <button class="battle-btn" onclick="runAway()">にげる</button>
+                    <button class="battle-button" onclick="attack()">こうげき</button>
+                    <button class="battle-button" onclick="useSkill()">とくぎ</button>
+                    <button class="battle-button" onclick="useItem()">どうぐ</button>
+                    <button class="battle-button" onclick="runAway()">にげる</button>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -549,6 +549,7 @@ function startBattle(enemyType) {
     const enemyHP = document.getElementById('enemyHP');
     
     battleScreen.classList.remove('hidden');
+    document.querySelector('.next-button').style.display = 'none';
     enemyImage.src = gameState.currentEnemy.image;
     enemyImage.alt = gameState.currentEnemy.name;
     enemyName.textContent = gameState.currentEnemy.name;
@@ -713,6 +714,7 @@ function endBattle() {
     
     setTimeout(() => {
         document.getElementById('battleScreen').classList.add('hidden');
+        document.querySelector('.next-button').style.display = 'inline-block';
     }, 1000);
 }
 

--- a/style.css
+++ b/style.css
@@ -10,6 +10,11 @@ body {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   overflow: hidden;
   height: 100vh;
+}
+
+html, body {
+  touch-action: manipulation;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -352,20 +357,37 @@ body {
   margin: 0 auto;
 }
 
-.battle-btn {
-  padding: 15px;
-  font-size: 1.1rem;
+.battle-button {
+  padding: 16px;
+  margin: 8px 0;
+  font-size: 18px;
+  min-height: 48px;
+  width: 80%;
+  max-width: 280px;
+  border-radius: 8px;
+  box-sizing: border-box;
   background: #2980b9;
   color: white;
   border: none;
-  border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.battle-btn:hover {
+.battle-button:hover {
   background: #3498db;
   transform: scale(1.05);
+}
+
+.battle-modal {
+  z-index: 1000;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #f88;
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
 }
 
 /* 移動コントロール（スマホ用） */


### PR DESCRIPTION
## Summary
- Prevent mobile zoom and accidental text selection
- Add larger battle buttons and modal styling
- Hide message navigation while battle modal is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894709e91dc833087264c48f4ea2fa4