### PR TITLE
Refine battle UI layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -321,6 +321,8 @@ html, body {
   padding: 20px;
   color: white;
   text-align: center;
+  width: 640px;
+  max-width: 90%;
 }
 
 .enemy-area {
@@ -349,21 +351,23 @@ html, body {
   font-weight: bold;
 }
 
+
 .battle-menu {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
   gap: 10px;
-  max-width: 400px;
+  max-width: 600px;
   margin: 0 auto;
 }
 
 .battle-button {
   padding: 16px;
-  margin: 8px 0;
+  margin: 0;
   font-size: 18px;
   min-height: 48px;
-  width: 80%;
-  max-width: 280px;
+  width: 100%;
+  max-width: none;
   border-radius: 8px;
   box-sizing: border-box;
   background: #2980b9;
@@ -384,7 +388,7 @@ html, body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: #f88;
+  background: transparent;
   padding: 24px;
   border-radius: 16px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- expand battle area width for a more spacious combat display
- arrange battle commands into a 2×2 grid with full-width buttons
- streamline modal styling so the gradient backdrop is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a0285d9483308f6ea2d4fe65fd0b