### PR TITLE
Use SVG for castle and cave icons

### DIFF
--- a/images/tiles/castle.svg
+++ b/images/tiles/castle.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <rect x="4" y="18" width="32" height="18" fill="#d0d0d0" stroke="#555"/>
+  <rect x="8" y="10" width="8" height="10" fill="#d0d0d0" stroke="#555"/>
+  <rect x="24" y="10" width="8" height="10" fill="#d0d0d0" stroke="#555"/>
+  <polygon points="8,10 12,6 16,10" fill="#d0d0d0" stroke="#555"/>
+  <polygon points="24,10 28,6 32,10" fill="#d0d0d0" stroke="#555"/>
+  <rect x="17" y="24" width="6" height="12" fill="#888" stroke="#555"/>
+  <rect x="19" y="28" width="2" height="8" fill="#555"/>
+  <rect x="4" y="18" width="32" height="4" fill="#bbb" stroke="#555"/>
+</svg>

--- a/images/tiles/cave.svg
+++ b/images/tiles/cave.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <path d="M5 35 L20 8 L35 35 Z" fill="#8b5a2b" stroke="#654321" stroke-width="2"/>
+  <ellipse cx="20" cy="26" rx="8" ry="10" fill="#000"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -60,11 +60,6 @@
                     <div style="text-align: center; line-height: 60px; font-size: 20px;">🌉</div>
                 </div>
                 
-                <!-- 洞窟 -->
-                <div class="cave" style="position: absolute; left: 350px; top: 280px;">
-                    <div style="font-size: 40px;">🕳️</div>
-                </div>
-                
                 <!-- その他の地形 -->
                 <div class="forest tile-forest" style="position: absolute; left: 300px; top: 300px;"></div>
             </div>

--- a/script.js
+++ b/script.js
@@ -290,13 +290,13 @@ function createFieldEvents() {
                 eventElement.textContent = '⛰️';
                 break;
             case 'cave':
-                eventElement.textContent = '🕳️';
+                eventElement.innerHTML = '<img src="images/tiles/cave.svg" alt="洞窟">';
                 break;
             case 'bridge':
                 eventElement.textContent = '🌉';
                 break;
             case 'dungeon':
-                eventElement.textContent = '🏰';
+                eventElement.innerHTML = '<img src="images/tiles/castle.svg" alt="城">';
                 break;
             case 'forest':
                 eventElement.textContent = '🌲';

--- a/style.css
+++ b/style.css
@@ -506,6 +506,12 @@ html, body {
   filter: brightness(1.3);
 }
 
+.field-event img {
+  width: 100%;
+  height: 100%;
+}
+
+
 /* BGM音量調整用スタイル */
 .volume-control {
   position: fixed;


### PR DESCRIPTION
## Summary
- add castle.svg and cave.svg icons for field events
- replace dungeon and cave emojis with new SVG images
- ensure field event styling supports SVG icons

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6895678304f083309dd5498741c6c2d4