### PR TITLE
Center field and add river bridge

### DIFF
--- a/images/tiles/bridge.svg
+++ b/images/tiles/bridge.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+  <rect x="0" y="0" width="40" height="40" fill="#b5651d"/>
+  <line x1="0" y1="5" x2="40" y2="5" stroke="#8b4513" stroke-width="2"/>
+  <line x1="0" y1="15" x2="40" y2="15" stroke="#8b4513" stroke-width="2"/>
+  <line x1="0" y1="25" x2="40" y2="25" stroke="#8b4513" stroke-width="2"/>
+  <line x1="0" y1="35" x2="40" y2="35" stroke="#8b4513" stroke-width="2"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -30,10 +30,13 @@
         <!-- ゲームエリア -->
         <div id="gameArea">
             <!-- フィールド -->
-            <div id="field" class="tile-grass"></div>
+            <div id="field" class="tile-grass">
+                <div class="river tile-water"></div>
+                <div class="bridge tile-bridge"></div>
+            </div>
 
             <!-- SVG勇者プレイヤー -->
-            <div id="player" class="character" style="top: 200px; left: 400px;">
+            <div id="player" class="character" style="top: 160px; left: 400px;">
                 <svg width="40" height="40" viewBox="0 0 40 40" id="playerSvg">
                     <!-- 体 -->
                     <ellipse cx="20" cy="30" rx="8" ry="10" fill="#4a90e2" stroke="#2c3e50" stroke-width="1"/>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 const CELL_SIZE = 40;
-const mapWidth = 20;
+const mapWidth = 30;
 const mapHeight = 10;
 
 // ゲームの状態管理
@@ -9,7 +9,7 @@ let gameState = {
         name: 'カケル',
         gender: 'boy',
         x: 10 * CELL_SIZE,
-        y: 5 * CELL_SIZE,
+        y: 4 * CELL_SIZE,
         hp: 100,
         maxHp: 100,
         mp: 50,
@@ -56,10 +56,10 @@ const enemies = {
 
 // フィールドイベント（20x10グリッドに再配置）
 const fieldEvents = [
-    { x: 10 * CELL_SIZE, y: 5 * CELL_SIZE, type: 'village', message: 'スタート村。ここでセーブできます。' },
+    { x: 10 * CELL_SIZE, y: 4 * CELL_SIZE, type: 'village', message: 'スタート村。ここでセーブできます。' },
     { x: 18 * CELL_SIZE, y: 1 * CELL_SIZE, type: 'castle', message: '魔王城がそびえ立つ… 戦いの準備はいいか？', enemy: 'demon' },
     { x: 14 * CELL_SIZE, y: 6 * CELL_SIZE, type: 'forest', message: '森の迷路だ。モンスターに注意！' },
-    { x: 7 * CELL_SIZE, y: 5 * CELL_SIZE, type: 'river', message: '湖と橋がある。橋以外は渡れない。' },
+    { x: 7 * CELL_SIZE, y: 5 * CELL_SIZE, type: 'bridge', message: '古い木の橋だ。ここを通れば川を渡れる。' },
     { x: 3 * CELL_SIZE, y: 8 * CELL_SIZE, type: 'ruins', message: '古い遺跡を発見！ 謎を解いて宝を手に入れた。' },
     { x: 2 * CELL_SIZE, y: 2 * CELL_SIZE, type: 'volcano', message: '火山地帯だ。炎の魔物が現れた！', enemy: 'goblin' },
     { x: 17 * CELL_SIZE, y: 8 * CELL_SIZE, type: 'village', message: '雪原の村に到着。装備を強化できそうだ。' },
@@ -299,7 +299,10 @@ function createFieldEvents() {
                 eventElement.textContent = '🏰';
                 break;
             case 'river':
-                eventElement.textContent = '🌊';
+                eventElement.style.display = 'none';
+                break;
+            case 'bridge':
+                eventElement.style.display = 'none';
                 break;
             case 'ruins':
                 eventElement.textContent = '🏚️';

--- a/style.css
+++ b/style.css
@@ -113,13 +113,13 @@ html, body {
 
 #gameArea {
   position: relative;
-  width: 800px;
+  width: 1200px;
   height: 400px;
   background: #27ae60;
   border: 3px solid #2c3e50;
   border-radius: 10px;
   overflow: hidden;
-  margin-bottom: 10px;
+  margin: 0 auto 10px;
 }
 
 /* フィールド */
@@ -133,7 +133,8 @@ html, body {
 .tile-grass,
 .tile-forest,
 .tile-water,
-.tile-road {
+.tile-road,
+.tile-bridge {
   background-size: 40px 40px;
   background-repeat: repeat;
 }
@@ -152,6 +153,28 @@ html, body {
 
 .tile-road {
   background-image: url('images/tiles/road.svg');
+}
+
+.tile-bridge {
+  background-image: url('images/tiles/bridge.svg');
+}
+
+.river {
+  position: absolute;
+  top: 200px;
+  left: 0;
+  width: 100%;
+  height: 40px;
+  z-index: 1;
+}
+
+.bridge {
+  position: absolute;
+  top: 200px;
+  left: 280px;
+  width: 40px;
+  height: 40px;
+  z-index: 2;
 }
 
 /* 地形要素 */


### PR DESCRIPTION
## Summary
- Center game area and expand field width to 150%
- Add river with SVG water and new bridge graphic
- Move player start and register bridge event for proper crossing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895e665ba7c833093576be8719afa6d