### PR TITLE
Enable horizontal scrolling on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -853,10 +853,9 @@ let touchStartY = 0;
 document.getElementById('gameArea').addEventListener('touchstart', function(e) {
     if (gameState.currentScreen !== 'gameScreen') return;
     if (gameState.inBattle) return;
-    
+
     touchStartX = e.touches[0].clientX;
     touchStartY = e.touches[0].clientY;
-    e.preventDefault();
 });
 
 document.getElementById('gameArea').addEventListener('touchend', function(e) {
@@ -888,8 +887,6 @@ document.getElementById('gameArea').addEventListener('touchend', function(e) {
             }
         }
     }
-    
-    e.preventDefault();
 });
 
 // ダブルタップでイベントチェック

--- a/style.css
+++ b/style.css
@@ -8,7 +8,8 @@
 body {
   font-family: 'Arial', sans-serif;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   height: 100vh;
 }
 
@@ -113,19 +114,20 @@ html, body {
 
 #gameArea {
   position: relative;
-  width: 1200px;
+  width: 100%;
   height: 400px;
   background: #27ae60;
   border: 3px solid #2c3e50;
   border-radius: 10px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   margin: 0 auto 10px;
 }
 
 /* フィールド */
 #field {
-  width: 100%;
-  height: 100%;
+  width: 1200px;
+  height: 400px;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- Allow horizontal scrolling by making the game area scrollable and adjusting its field size for wide maps
- Remove touch event prevention so mobile gestures can scroll the map

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897e4637fe88330ab301cd52ddbb248