### PR TITLE
敵画像の大きさを200%に拡大

### DIFF
--- a/style.css
+++ b/style.css
@@ -355,8 +355,8 @@ html, body {
 }
 
 .enemy-image {
-  width: 120px;
-  height: 120px;
+  width: 240px;
+  height: 240px;
   object-fit: contain;
   margin-bottom: 10px;
   animation: enemyShake 1s ease-in-out infinite;
@@ -580,8 +580,8 @@ html, body {
   }
   
   .enemy-image {
-      width: 100px;
-      height: 100px;
+      width: 200px;
+      height: 200px;
   }
   
   .town {
@@ -614,8 +614,8 @@ html, body {
   }
   
   .enemy-image {
-      width: 80px;
-      height: 80px;
+      width: 160px;
+      height: 160px;
   }
   
   .building {


### PR DESCRIPTION
## Summary
- 敵画像クラスの幅・高さを2倍に変更し、バトル画面の敵を200%表示
- レスポンシブ向けの敵画像サイズも同様に2倍へ調整

## Testing
- `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c7fa675708330b8ca57742c4f7067